### PR TITLE
Controller: run stream

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -57,12 +57,14 @@ pub async fn start_receive(client: ClientHandle, my_channel: mpsc::Sender<Event>
                 ))
                 .unwrap();
             }
-            Command::PRIVMSG(ref target, ref msg) =>
-            // {
-            {
-                m1.send(Event::IrcMessage(target.to_string(), msg.to_string()))
-                    .unwrap()
-            }
+            Command::PRIVMSG(ref target, ref msg) => match m.source_nickname() {
+                Some(inner) => m1
+                    .send(Event::IrcMessage(inner.to_string(), msg.to_string()))
+                    .unwrap(),
+                None => m1
+                    .send(Event::IrcMessage(target.to_string(), msg.to_string()))
+                    .unwrap(),
+            },
             _ => m1
                 .send(Event::IrcMessage("".to_string(), m.to_string()))
                 .unwrap(),


### PR DESCRIPTION
Replace message target with source_nick when sending PRIVMSG to main. Previous refactor had unintended side
effect of printing message target instead of source_nick to screen.

Signed-off-by: Briana Oursler <briana.oursler@gmail.com>